### PR TITLE
Improve handling of Async IO

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,6 +33,18 @@ jobs:
         run: |
           brew install hwloc bison flex gdal
 
+      - name: (Linux) Install dependencies
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y gcc-9 g++-9
+
+      - name: (Linux) Set GCC9 as default compiler
+        uses: lukka/set-shell-env@master
+        if: runner.os == 'Linux'
+        with:
+          CMAKE_EXTRA_ARGS: '-DCMAKE_C_COMPILER=/usr/bin/gcc-9 -DCMAKE_CXX_COMPILER=/usr/bin/g++-9'
+
       - name: Restore artifacts, or run vcpkg, build and cache artifacts
         uses: lukka/run-vcpkg@v3
         id: runvcpkg
@@ -49,7 +61,7 @@ jobs:
           cmakeListsOrSettingsJson: "CMakeListsTxtAdvanced"
           useVcpkgToolchainFile: true
           buildDirectory: '${{ github.workspace }}/build/'
-          cmakeAppendedArgs: '-GNinja -DCI=ON'
+          cmakeAppendedArgs: '-GNinja -DCI=ON ${{ env.CMAKE_EXTRA_ARGS }}'
 
       - name: Unit Tests
         run: |

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -2,6 +2,7 @@ find_package(Boost COMPONENTS filesystem regex program_options system iostreams 
 # If we're using our own copy of HPX, we need to crate an alias target to match what find_pacakage would return
 if (${USE_INTERNAL_HPX})
     add_library(HPX::hpx ALIAS hpx)
+    add_library(HPX::wrap_main ALIAS wrap_main)
 else ()
     find_package(HPX CONFIG REQUIRED)
 endif ()

--- a/src/map-tile/CMakeLists.txt
+++ b/src/map-tile/CMakeLists.txt
@@ -14,7 +14,7 @@ target_include_directories(map-tile PUBLIC
 target_compile_definitions(map-tile PUBLIC EMIT_SIZE=${EMIT_SIZE})
 
 add_executable(testmap-tile-runtime test/runtime_tests.cpp)
-target_link_libraries(testmap-tile-runtime Catch2::Catch2 map-tile io Boost::filesystem absl::strings Eigen3::Eigen)
+target_link_libraries(testmap-tile-runtime HPX::wrap_main Catch2::Catch2 map-tile io Boost::filesystem absl::strings Eigen3::Eigen)
 add_test(map-tile testmap-tile-runtime WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/map-tile/test)
 
 add_executable(map-tile-unit-tests test/locator_tests.cpp test/serialization_tests.cpp test/tiler_tests.cpp)

--- a/src/map-tile/CMakeLists.txt
+++ b/src/map-tile/CMakeLists.txt
@@ -1,16 +1,16 @@
 # We don't require Eigen to build the project, but the tests do require it
 find_package(Eigen3 3.3 NO_MODULE)
 
-add_library(map-tile include/map-tile/server/MapTileServer.hpp src/FileProvider.cpp include/map-tile/io/FileProvider.hpp include/map-tile/ctx/Context.hpp include/map-tile/client/MapTileClient.hpp include/map-tile/coordinates/LocaleLocator.hpp src/coordinates/Coordinate2D.cpp include/map-tile/coordinates/Coordinate2D.hpp src/coordinates/LocaleTiler.cpp include/map-tile/coordinates/LocaleTiler.hpp src/coordinates/Coordinate3D.cpp include/map-tile/coordinates/Coordinate3D.hpp include/traits.hpp)
+add_library(map-tile include/map-tile/server/MapTileServer.hpp src/FileProvider.cpp include/map-tile/io/FileProvider.hpp include/map-tile/ctx/Context.hpp include/map-tile/client/MapTileClient.hpp include/map-tile/coordinates/LocaleLocator.hpp src/coordinates/Coordinate2D.cpp include/map-tile/coordinates/Coordinate2D.hpp src/coordinates/LocaleTiler.cpp include/map-tile/coordinates/LocaleTiler.hpp src/coordinates/Coordinate3D.cpp include/map-tile/coordinates/Coordinate3D.hpp include/traits.hpp include/map-tile/io/EmitHandler.hpp)
 
 target_link_libraries(map-tile PUBLIC HPX::hpx spdlog shared PRIVATE Boost::iostreams)
 target_include_directories(map-tile PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)
 
-#add_executable(testmap-tile-runtime test/runtime_tests.cpp)
-#target_link_libraries(testmap-tile-runtime Catch2::Catch2 map-tile io Boost::filesystem absl::strings Eigen3::Eigen)
-#add_test(map-tile testmap-tile-runtime WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/map-tile/test)
+add_executable(testmap-tile-runtime test/runtime_tests.cpp)
+target_link_libraries(testmap-tile-runtime Catch2::Catch2 map-tile io Boost::filesystem absl::strings Eigen3::Eigen)
+add_test(map-tile testmap-tile-runtime WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src/map-tile/test)
 
 add_executable(map-tile-unit-tests test/locator_tests.cpp test/serialization_tests.cpp test/tiler_tests.cpp)
 target_link_libraries(map-tile-unit-tests Catch2::Catch2 map-tile io Boost::filesystem absl::strings)

--- a/src/map-tile/CMakeLists.txt
+++ b/src/map-tile/CMakeLists.txt
@@ -1,12 +1,17 @@
 # We don't require Eigen to build the project, but the tests do require it
 find_package(Eigen3 3.3 NO_MODULE)
 
-add_library(map-tile include/map-tile/server/MapTileServer.hpp src/FileProvider.cpp include/map-tile/io/FileProvider.hpp include/map-tile/ctx/Context.hpp include/map-tile/client/MapTileClient.hpp include/map-tile/coordinates/LocaleLocator.hpp src/coordinates/Coordinate2D.cpp include/map-tile/coordinates/Coordinate2D.hpp src/coordinates/LocaleTiler.cpp include/map-tile/coordinates/LocaleTiler.hpp src/coordinates/Coordinate3D.cpp include/map-tile/coordinates/Coordinate3D.hpp include/traits.hpp include/map-tile/io/EmitHandler.hpp)
+set(EMIT_SIZE 4096 CACHE STRING "Buffer size (bytes) before emitting")
+
+
+add_library(map-tile include/map-tile/server/MapTileServer.hpp src/FileProvider.cpp include/map-tile/io/FileProvider.hpp include/map-tile/ctx/Context.hpp include/map-tile/client/MapTileClient.hpp include/map-tile/coordinates/LocaleLocator.hpp src/coordinates/Coordinate2D.cpp include/map-tile/coordinates/Coordinate2D.hpp src/coordinates/LocaleTiler.cpp include/map-tile/coordinates/LocaleTiler.hpp src/coordinates/Coordinate3D.cpp include/map-tile/coordinates/Coordinate3D.hpp include/traits.hpp include/map-tile/io/EmitHandler.hpp src/io/EmitHelpers.cpp include/map-tile/io/EmitHelpers.hpp)
 
 target_link_libraries(map-tile PUBLIC HPX::hpx spdlog shared PRIVATE Boost::iostreams)
 target_include_directories(map-tile PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)
+
+target_compile_definitions(map-tile PUBLIC EMIT_SIZE=${EMIT_SIZE})
 
 add_executable(testmap-tile-runtime test/runtime_tests.cpp)
 target_link_libraries(testmap-tile-runtime Catch2::Catch2 map-tile io Boost::filesystem absl::strings Eigen3::Eigen)

--- a/src/map-tile/include/map-tile/coordinates/Coordinate2D.hpp
+++ b/src/map-tile/include/map-tile/coordinates/Coordinate2D.hpp
@@ -19,6 +19,7 @@ namespace mt::coordinates {
         static constexpr int dimensions = 2;
 
         Coordinate2D() = default;
+        Coordinate2D& operator=(const Coordinate2D&) = default;
 
         Coordinate2D(const std::size_t &dim0, const std::size_t &dim1);
 

--- a/src/map-tile/include/map-tile/coordinates/LocaleLocator.hpp
+++ b/src/map-tile/include/map-tile/coordinates/LocaleLocator.hpp
@@ -30,6 +30,10 @@ namespace mt::coordinates {
 
         explicit LocaleLocator(const std::vector<value> &tiles) : _index(tiles.begin(), tiles.end()) {
             // Not used
+            const auto sz = tiles.size();
+            if (sz == 0) {
+                throw std::invalid_argument("Nothing here");
+            }
         };
 
         LocaleLocator<Coordinate>() = default;

--- a/src/map-tile/include/map-tile/coordinates/LocaleLocator.hpp
+++ b/src/map-tile/include/map-tile/coordinates/LocaleLocator.hpp
@@ -43,7 +43,6 @@ namespace mt::coordinates {
 
             // Use the index to filter down the list
             _index.query(bg::index::covers(coords), std::back_inserter(values));
-
             if (values.empty()) {
                 throw std::invalid_argument("Out of bounds");
             }

--- a/src/map-tile/include/map-tile/coordinates/LocaleLocator.hpp
+++ b/src/map-tile/include/map-tile/coordinates/LocaleLocator.hpp
@@ -38,6 +38,10 @@ namespace mt::coordinates {
 
         LocaleLocator<Coordinate>() = default;
 
+        [[nodiscard]] std::size_t get_num_locales() const {
+            return _index.size();
+        }
+
         [[nodiscard]] std::uint64_t get_locale(const Coordinate &coords) const {
             std::vector<value> values;
 

--- a/src/map-tile/include/map-tile/io/EmitHandler.hpp
+++ b/src/map-tile/include/map-tile/io/EmitHandler.hpp
@@ -6,21 +6,27 @@
 #define MOBILITY_CPP_EMITHANDLER_HPP
 
 #include "../coordinates/LocaleLocator.hpp"
+#include "EmitHelpers.hpp"
+#include <absl/synchronization/mutex.h>
 #include <hpx/include/parallel_executors.hpp>
 #include <hpx/include/runtime.hpp>
 #include <hpx/io_service/io_service_pool.hpp>
 #include <spdlog/fmt/fmt.h>
 #include <memory>
+#include <mutex>
 #include <utility>
 
 namespace mt::io {
 
     template<typename S, typename C, typename K>
-    void handle_emit(std::shared_ptr<std::pair<const C, const K>> ptr, const coordinates::LocaleLocator <C> &locator) {
-        const auto locale_num = locator.get_locale(ptr->first);
+    void handle_emit(std::vector<std::pair<const C, const K>> ptr,
+                     const std::size_t locale_num) {
         auto id = hpx::find_from_basename(fmt::format("mt/base/{}", locale_num), 0).get();
         typedef typename S::receive_action action_type;
-        hpx::apply<action_type>(id, ptr->first, ptr->second);
+        std::for_each(ptr.begin(), ptr.end(), [&id](auto v) {
+            hpx::apply<action_type>(id, v.first, v.second);
+        });
+
     }
 
     template<typename Server, typename Coordinate, typename Key>
@@ -28,23 +34,40 @@ namespace mt::io {
 
     public:
         typedef typename std::pair<const Coordinate, const Key> emit_value;
+        typedef typename std::shared_ptr<emit_value> ptr_value;
 
-        explicit EmitHandler(const coordinates::LocaleLocator <Coordinate> locator) : _locator(std::move(locator)),
+        static constexpr std::size_t array_size = get_array_size<emit_value>();
+
+        explicit EmitHandler(const coordinates::LocaleLocator<Coordinate> locator) : _locator(std::move(locator)),
                 // Get the IO pool manually, so we can wait for everything to finish
-                                                                                      _pool(hpx::get_runtime().get_thread_pool(
-                                                                                              "io_pool")),
-                                                                                      _executor(
-                                                                                              hpx::parallel::execution::io_pool_executor()) {
+                                                                                     _pool(hpx::get_runtime().get_thread_pool(
+                                                                                             "io_pool")),
+                                                                                     _executor(
+                                                                                             hpx::parallel::execution::io_pool_executor()),
+                                                                                     _buffer(locator.get_num_locales()) {
+
         };
 
-        void emit(std::shared_ptr<emit_value> value) const {
-            hpx::async(_executor, &handle_emit<Server, Coordinate, Key>, value, _locator).get();
+        void emit(std::shared_ptr<emit_value> value) {
+            const auto locale_num = _locator.get_locale(value->first);
+            const auto out_buffer = _buffer.add_to_buffer(locale_num, value);
+            if (out_buffer.has_value()) {
+                hpx::async(_executor, &handle_emit<Server, Coordinate, Key>, std::move(*out_buffer), locale_num).get();
+            }
+        }
+
+        void flush() const {
+            const auto vals = _buffer.flush();
+            for (std::size_t i = 0; i < vals.size(); i++) {
+                hpx::async(_executor, &handle_emit<Server, Coordinate, Key>, std::move(vals[i]), i).get();
+            }
         }
 
     private:
         hpx::util::io_service_pool *_pool;
         hpx::parallel::execution::io_pool_executor _executor;
-        const coordinates::LocaleLocator <Coordinate> _locator;
+        const coordinates::LocaleLocator<Coordinate> _locator;
+        EmitBuffer<Coordinate, Key> _buffer;
     };
 }
 

--- a/src/map-tile/include/map-tile/io/EmitHandler.hpp
+++ b/src/map-tile/include/map-tile/io/EmitHandler.hpp
@@ -1,0 +1,49 @@
+//
+// Created by Nicholas Robison on 8/13/20.
+//
+
+#ifndef MOBILITY_CPP_EMITHANDLER_HPP
+#define MOBILITY_CPP_EMITHANDLER_HPP
+
+#include "../coordinates/LocaleLocator.hpp"
+#include <hpx/include/parallel_executors.hpp>
+#include <spdlog/fmt/fmt.h>
+#include <memory>
+#include <utility>
+
+namespace mt::io {
+
+    template <typename S, typename C, typename K>
+    void handle_emit(std::shared_ptr<std::pair<const C, const K>> ptr, const coordinates::LocaleLocator<C> &locator) {
+        const auto locale_num = locator.get_locale(ptr->first);
+        const auto id = hpx::find_from_basename(fmt::format("mt/base/{}", locale_num), 0).get();
+        typedef typename S::receive_action action_type;
+        try {
+            hpx::async<action_type>(id, ptr->first, ptr->second).get();
+        } catch (const std::exception &e) {
+            spdlog::error("Unable to send value. {}", e.what());
+        }
+    }
+
+    template <typename Server, typename Coordinate, typename Key>
+    class EmitHandler {
+
+    public:
+        typedef typename std::pair<const Coordinate, const Key> emit_value;
+        // Default constructors don't work here, we need to be explicit
+        EmitHandler() {
+            // Not used
+        };
+
+        void emit(std::shared_ptr<emit_value> value) const {
+            hpx::apply(_pool, &handle_emit<Server, Coordinate, Key>, value, _locator);
+        }
+
+
+    private:
+        const hpx::parallel::execution::io_pool_executor _pool;
+        const coordinates::LocaleLocator<Coordinate> _locator;
+    };
+}
+
+#endif //MOBILITY_CPP_EMITHANDLER_HPP

--- a/src/map-tile/include/map-tile/io/EmitHandler.hpp
+++ b/src/map-tile/include/map-tile/io/EmitHandler.hpp
@@ -7,42 +7,61 @@
 
 #include "../coordinates/LocaleLocator.hpp"
 #include <hpx/include/parallel_executors.hpp>
+#include <hpx/include/runtime.hpp>
+#include <hpx/io_service/io_service_pool.hpp>
 #include <spdlog/fmt/fmt.h>
+#include <atomic>
 #include <memory>
 #include <utility>
 
+std::atomic<std::uint32_t> in_flight = 0;
+
 namespace mt::io {
 
-    template <typename S, typename C, typename K>
-    void handle_emit(std::shared_ptr<std::pair<const C, const K>> ptr, const coordinates::LocaleLocator<C> &locator) {
+    template<typename S, typename C, typename K>
+    void handle_emit(std::shared_ptr<std::pair<const C, const K>> ptr, const coordinates::LocaleLocator <C> &locator) {
         const auto locale_num = locator.get_locale(ptr->first);
         const auto id = hpx::find_from_basename(fmt::format("mt/base/{}", locale_num), 0).get();
         typedef typename S::receive_action action_type;
         try {
+            spdlog::info("Emitting here");
+            in_flight++;
             hpx::async<action_type>(id, ptr->first, ptr->second).get();
+            spdlog::info("Emit done");
+            in_flight--;
+            spdlog::info("Current in flight: {}", in_flight);
         } catch (const std::exception &e) {
             spdlog::error("Unable to send value. {}", e.what());
         }
     }
 
-    template <typename Server, typename Coordinate, typename Key>
+    template<typename Server, typename Coordinate, typename Key>
     class EmitHandler {
 
     public:
         typedef typename std::pair<const Coordinate, const Key> emit_value;
-        // Default constructors don't work here, we need to be explicit
-        EmitHandler() {
-            // Not used
+
+        explicit EmitHandler(const coordinates::LocaleLocator <Coordinate> &locator) : _locator(locator),
+                // Get the IO pool manually, so we can wait for everything to finish
+                                                                                       _pool(hpx::get_runtime().get_thread_pool(
+                                                                                               "io_pool")),
+                                                                                       _executor(
+                                                                                               hpx::parallel::execution::detail::service_executor(
+                                                                                                       _pool)) {
         };
 
         void emit(std::shared_ptr<emit_value> value) const {
-            hpx::apply(_pool, &handle_emit<Server, Coordinate, Key>, value, _locator);
+            hpx::apply(_executor, &handle_emit<Server, Coordinate, Key>, value, _locator);
         }
 
+        void wait() const {
+            _pool->wait();
+        }
 
     private:
-        const hpx::parallel::execution::io_pool_executor _pool;
-        const coordinates::LocaleLocator<Coordinate> _locator;
+        hpx::util::io_service_pool *_pool;
+        hpx::parallel::execution::detail::service_executor _executor;
+        const coordinates::LocaleLocator <Coordinate> &_locator;
     };
 }
 

--- a/src/map-tile/include/map-tile/io/EmitHandler.hpp
+++ b/src/map-tile/include/map-tile/io/EmitHandler.hpp
@@ -41,7 +41,7 @@ namespace mt::io {
                                                                                              "io_pool")),
                                                                                      _executor(
                                                                                              hpx::parallel::execution::io_pool_executor()),
-                                                                                     _buffer(locator.get_num_locales()) {
+                                                                                     _buffer(hpx::get_num_localities().get()) {
 
         };
 

--- a/src/map-tile/include/map-tile/io/EmitHandler.hpp
+++ b/src/map-tile/include/map-tile/io/EmitHandler.hpp
@@ -10,29 +10,17 @@
 #include <hpx/include/runtime.hpp>
 #include <hpx/io_service/io_service_pool.hpp>
 #include <spdlog/fmt/fmt.h>
-#include <atomic>
 #include <memory>
 #include <utility>
-
-std::atomic<std::uint32_t> in_flight = 0;
 
 namespace mt::io {
 
     template<typename S, typename C, typename K>
     void handle_emit(std::shared_ptr<std::pair<const C, const K>> ptr, const coordinates::LocaleLocator <C> &locator) {
         const auto locale_num = locator.get_locale(ptr->first);
-        const auto id = hpx::find_from_basename(fmt::format("mt/base/{}", locale_num), 0).get();
+        auto id = hpx::find_from_basename(fmt::format("mt/base/{}", locale_num), 0).get();
         typedef typename S::receive_action action_type;
-        try {
-            spdlog::info("Emitting here");
-            in_flight++;
-            hpx::async<action_type>(id, ptr->first, ptr->second).get();
-            spdlog::info("Emit done");
-            in_flight--;
-            spdlog::info("Current in flight: {}", in_flight);
-        } catch (const std::exception &e) {
-            spdlog::error("Unable to send value. {}", e.what());
-        }
+        hpx::apply<action_type>(id, ptr->first, ptr->second);
     }
 
     template<typename Server, typename Coordinate, typename Key>
@@ -41,27 +29,22 @@ namespace mt::io {
     public:
         typedef typename std::pair<const Coordinate, const Key> emit_value;
 
-        explicit EmitHandler(const coordinates::LocaleLocator <Coordinate> &locator) : _locator(locator),
+        explicit EmitHandler(const coordinates::LocaleLocator <Coordinate> locator) : _locator(std::move(locator)),
                 // Get the IO pool manually, so we can wait for everything to finish
-                                                                                       _pool(hpx::get_runtime().get_thread_pool(
-                                                                                               "io_pool")),
-                                                                                       _executor(
-                                                                                               hpx::parallel::execution::detail::service_executor(
-                                                                                                       _pool)) {
+                                                                                      _pool(hpx::get_runtime().get_thread_pool(
+                                                                                              "io_pool")),
+                                                                                      _executor(
+                                                                                              hpx::parallel::execution::io_pool_executor()) {
         };
 
         void emit(std::shared_ptr<emit_value> value) const {
-            hpx::apply(_executor, &handle_emit<Server, Coordinate, Key>, value, _locator);
-        }
-
-        void wait() const {
-            _pool->wait();
+            hpx::async(_executor, &handle_emit<Server, Coordinate, Key>, value, _locator).get();
         }
 
     private:
         hpx::util::io_service_pool *_pool;
-        hpx::parallel::execution::detail::service_executor _executor;
-        const coordinates::LocaleLocator <Coordinate> &_locator;
+        hpx::parallel::execution::io_pool_executor _executor;
+        const coordinates::LocaleLocator <Coordinate> _locator;
     };
 }
 

--- a/src/map-tile/include/map-tile/io/EmitHandler.hpp
+++ b/src/map-tile/include/map-tile/io/EmitHandler.hpp
@@ -22,11 +22,8 @@ namespace mt::io {
     void handle_emit(std::vector<std::pair<const C, const K>> ptr,
                      const std::size_t locale_num) {
         auto id = hpx::find_from_basename(fmt::format("mt/base/{}", locale_num), 0).get();
-        typedef typename S::receive_action action_type;
-        std::for_each(ptr.begin(), ptr.end(), [&id](auto v) {
-            hpx::apply<action_type>(id, v.first, v.second);
-        });
-
+        typedef typename S::receive_array_action action_type;
+        hpx::apply<action_type>(id, ptr);
     }
 
     template<typename Server, typename Coordinate, typename Key>

--- a/src/map-tile/include/map-tile/io/EmitHelpers.hpp
+++ b/src/map-tile/include/map-tile/io/EmitHelpers.hpp
@@ -1,0 +1,95 @@
+//
+// Created by Nicholas Robison on 8/31/20.
+//
+
+#ifndef MOBILITY_CPP_EMITHELPERS_HPP
+#define MOBILITY_CPP_EMITHELPERS_HPP
+
+#include <spdlog/spdlog.h>
+#include <mutex>
+#include <optional>
+#include <utility>
+#include <vector>
+
+
+namespace mt::io {
+
+    constexpr double get_emit_buffer_size() {
+#ifdef EMIT_SIZE
+        return EMIT_SIZE;
+#else
+        return 0;
+#endif
+    }
+
+    template<typename Value>
+    constexpr std::size_t get_array_size() {
+        return static_cast<std::size_t>(get_emit_buffer_size() / sizeof(Value));
+    }
+
+    template<typename Coordinate, typename Value>
+    class EmitBuffer {
+
+    public:
+        typedef typename std::pair<const Coordinate, const Value> emit_value;
+        static constexpr std::size_t array_size = get_array_size<emit_value>();
+
+        explicit EmitBuffer(const std::size_t num_locales) : _buffer_cache(num_locales),
+                                                             _buffer_cache_size(num_locales),
+                                                             _buffer_locks(num_locales) {
+            spdlog::info("Initializing buffer for {} locales.", num_locales);
+            spdlog::info("Buffer of size: {}, holds {} values.", get_emit_buffer_size(), array_size);
+        }
+
+        std::optional<std::vector<emit_value>>
+        add_to_buffer(const std::size_t locale_num, std::shared_ptr<emit_value> value) {
+
+            std::lock_guard lock(_buffer_locks[locale_num]);
+            auto &locale_array = _buffer_cache[locale_num];
+            std::size_t &current_size = _buffer_cache_size[locale_num];
+
+            if (current_size < locale_array.size()) {
+                // Add to buffer
+                locale_array[current_size] = value;
+                current_size++;
+                return std::nullopt;
+            } else {
+                // Copy out the buffer
+                std::vector<emit_value> out_buffer;
+                out_buffer.reserve(array_size);
+                std::for_each(locale_array.begin(), locale_array.end(), [&out_buffer] (auto p) {
+                    out_buffer.push_back(*p);
+                });
+                locale_array[0] = value;
+                current_size = 1;
+                return {out_buffer};
+            }
+        }
+
+        std::vector<std::vector<emit_value>> flush() const {
+
+            std::vector<std::vector<emit_value>> output;
+            output.reserve(_buffer_cache.size());
+
+            for(std::size_t i = 0; i < _buffer_cache.size(); i++) {
+                const auto cur_size = _buffer_cache_size[i];
+                std::vector<emit_value> out_buffer;
+                out_buffer.reserve(cur_size);
+                auto locale_array = _buffer_cache[i];
+                for (std::size_t idx = 0; idx < cur_size; idx++) {
+                    out_buffer.push_back(*locale_array[idx]);
+                }
+                output.push_back(std::move(out_buffer));
+            }
+            return output;
+        }
+
+    private:
+        std::vector<std::size_t> _buffer_cache_size;
+        std::vector<std::mutex> _buffer_locks;
+        std::vector<std::array<std::shared_ptr<emit_value>, array_size>> _buffer_cache;
+    };
+}
+
+
+#endif //MOBILITY_CPP_EMITHELPERS_HPP

--- a/src/map-tile/include/map-tile/server/MapTileServer.hpp
+++ b/src/map-tile/include/map-tile/server/MapTileServer.hpp
@@ -51,7 +51,7 @@ namespace mt::server {
                                const mt_tile &tile,
                                const std::map<string, string> &config,
                                vector<string> files) : _files(
-                std::move(files)), _locator(locator), _tiler(Tiler{}),
+                std::move(files)), _tiler(Tiler{}),
                                                        _ctx(std::bind(&MapTileServer::handle_emit, this,
                                                                       std::placeholders::_1,
                                                                       std::placeholders::_2),
@@ -97,17 +97,9 @@ namespace mt::server {
                 //Map
                 hpx::parallel::for_each(hpx::parallel::execution::par, keys.begin(), keys.end(),
                                         [&ctx, &mapper](const auto &key) {
-                                            spdlog::info("Mapping here");
                                             mapper.map(ctx, key);
                                         });
             });
-            // Wait for everything to finish emitting
-//            spdlog::info("Waiting for emits to finish");
-//            hpx::future<void> waiter = hpx::async([this]() {
-//                _emitter.wait();
-//            });
-//            _emitter.wait();
-//            spdlog::info("Waited ok");
         }
 
         HPX_DEFINE_COMPONENT_ACTION(MapTileServer, tile);
@@ -138,13 +130,12 @@ namespace mt::server {
 
     private:
         const vector<string> _files;
-        const coordinates::LocaleLocator<Coordinate> _locator;
+//        const coordinates::LocaleLocator<Coordinate> _locator;
         const ctx::Context<MapKey, Coordinate> _ctx;
         Tiler _tiler;
         io::EmitHandler<mt::server::MapTileServer<MapKey, Coordinate, Mapper, Tiler, ReduceValue>, Coordinate, MapKey> _emitter;
 
         void handle_emit(const Coordinate &key, const MapKey &value) const {
-            spdlog::info("Do the emit");
             std::pair<const Coordinate, const MapKey> pair = std::make_pair(key, value);
             _emitter.emit(std::make_shared<std::pair<const Coordinate, const MapKey>>(pair));
         }

--- a/src/map-tile/include/map-tile/server/MapTileServer.hpp
+++ b/src/map-tile/include/map-tile/server/MapTileServer.hpp
@@ -137,6 +137,7 @@ namespace mt::server {
             const auto locale_num = _locator.get_locale(key);
             const auto id = hpx::find_from_basename(fmt::format("mt/base/{}", locale_num), 0).get();
             typedef typename mt::server::MapTileServer<MapKey, Coordinate, Mapper, Tiler, ReduceValue>::receive_action action_type;
+            typedef typename mt::server::MapTileServer<MapKey, Coordinate, Mapper, Tiler>::receive_action action_type;
             try {
                 hpx::async<action_type>(id, key, value).get();
             } catch (const std::exception &e) {

--- a/src/map-tile/include/map-tile/server/MapTileServer.hpp
+++ b/src/map-tile/include/map-tile/server/MapTileServer.hpp
@@ -102,6 +102,7 @@ namespace mt::server {
             });
 
             // Flush any remaining values
+            spdlog::info("Flushing remaining values");
             _emitter.flush();
         }
 

--- a/src/map-tile/include/map-tile/server/MapTileServer.hpp
+++ b/src/map-tile/include/map-tile/server/MapTileServer.hpp
@@ -113,6 +113,14 @@ namespace mt::server {
 
         HPX_DEFINE_COMPONENT_ACTION(MapTileServer, receive);
 
+        void receive_array(const std::vector<std::pair<const Coordinate, const MapKey>> &values) {
+            std::for_each(values.begin(), values.end(), [this](const auto v) {
+                _tiler.receive(_ctx, v.first, v.second);
+            });
+        }
+
+        HPX_DEFINE_COMPONENT_ACTION(MapTileServer, receive_array);
+
         void compute() {
             _tiler.compute(_ctx);
         }
@@ -155,8 +163,14 @@ namespace mt::server {
          ::mt::server::MapTileServer<map_key, coordinate, mapper, tiler, reduce_value, input_key, provider>::receive_action;  \
     HPX_REGISTER_ACTION(                                       \
         HPX_PP_CAT(HPX_PP_CAT(__MapTileServer_receive_action_, mapper), _type),    \
-        HPX_PP_CAT(__MapTileServer_receive_action_, mapper));                                        \
-                                                                                                        \
+        HPX_PP_CAT(__MapTileServer_receive_action_, mapper));                                                         \
+                                                                                                                      \
+        using HPX_PP_CAT(HPX_PP_CAT(__MapTileServer_receive_array_action_, mapper), _type) = \
+         ::mt::server::MapTileServer<map_key, coordinate, mapper, tiler, reduce_value, input_key, provider>::receive_array_action;  \
+    HPX_REGISTER_ACTION(                                       \
+        HPX_PP_CAT(HPX_PP_CAT(__MapTileServer_receive_array_action_, mapper), _type),    \
+        HPX_PP_CAT(__MapTileServer_receive_array_action_, mapper));                                                   \
+                                                                                                                      \
     using HPX_PP_CAT(HPX_PP_CAT(__MapTileServer_compute_action_, mapper), _type) = \
          ::mt::server::MapTileServer<map_key, coordinate, mapper, tiler, reduce_value, input_key, provider>::compute_action;  \
     HPX_REGISTER_ACTION(                                       \

--- a/src/map-tile/include/map-tile/server/MapTileServer.hpp
+++ b/src/map-tile/include/map-tile/server/MapTileServer.hpp
@@ -100,6 +100,9 @@ namespace mt::server {
                                             mapper.map(ctx, key);
                                         });
             });
+
+            // Flush any remaining values
+            _emitter.flush();
         }
 
         HPX_DEFINE_COMPONENT_ACTION(MapTileServer, tile);
@@ -130,12 +133,11 @@ namespace mt::server {
 
     private:
         const vector<string> _files;
-//        const coordinates::LocaleLocator<Coordinate> _locator;
         const ctx::Context<MapKey, Coordinate> _ctx;
         Tiler _tiler;
         io::EmitHandler<mt::server::MapTileServer<MapKey, Coordinate, Mapper, Tiler, ReduceValue>, Coordinate, MapKey> _emitter;
 
-        void handle_emit(const Coordinate &key, const MapKey &value) const {
+        void handle_emit(const Coordinate &key, const MapKey &value) {
             std::pair<const Coordinate, const MapKey> pair = std::make_pair(key, value);
             _emitter.emit(std::make_shared<std::pair<const Coordinate, const MapKey>>(pair));
         }

--- a/src/map-tile/src/io/EmitHelpers.cpp
+++ b/src/map-tile/src/io/EmitHelpers.cpp
@@ -1,0 +1,15 @@
+//
+// Created by Nicholas Robison on 8/31/20.
+//
+
+#include "map-tile/io/EmitHelpers.hpp"
+
+namespace mt::io {
+    /*constexpr int get_emit_buffer_size() {
+#ifdef EMIT_SIZE
+        return EMIT_SIZE;
+#else
+        return 0;
+#endif
+    }*/
+}

--- a/src/map-tile/test/runtime_tests.cpp
+++ b/src/map-tile/test/runtime_tests.cpp
@@ -114,19 +114,15 @@ struct FlightTile {
     void receive(const mt::ctx::ReduceContext<FlightInfo, mt::coordinates::Coordinate2D> &ctx, const mt::coordinates::Coordinate2D &key,
                  const FlightInfo &value) {
         // Just increment a simple counter
-        spdlog::info("Receiving");
         const std::lock_guard<std::mutex> lock(_m);
         _flight_matrix.coeffRef(key.get_dim0(), key.get_dim1()) += 1;
-        spdlog::info("Receive done");
     }
 
     void compute(const mt::ctx::ReduceContext<FlightInfo, mt::coordinates::Coordinate2D> &ctx) {
-        spdlog::info("Doing the compute");
         _local_total = _flight_matrix.sum();
     }
 
     double reduce(const mt::ctx::ReduceContext<FlightInfo, mt::coordinates::Coordinate2D> &ctx) {
-        spdlog::info("Doing the reduce");
         return _local_total;
     }
 

--- a/src/map-tile/test/runtime_tests.cpp
+++ b/src/map-tile/test/runtime_tests.cpp
@@ -151,6 +151,13 @@ TEST_CASE("Flight Mapper", "[integration]") {
     const mt::coordinates::LocaleLocator<Coordinate2D> l(tiles);
     std::vector<string> files{"data/routes.csv"};
 
+    std::for_each(tiles.begin(), tiles.end(), [](const auto tile) {
+        spdlog::info("Locale: {} has tile from: {}/{}, to: {}/{}",
+                      tile.second, tile.first.min_corner().get_dim0(), tile.first.min_corner().get_dim1(),
+                      tile.first.max_corner().get_dim0(),
+                      tile.first.max_corner().get_dim1());
+    });
+
     // Create the servers
     std::vector<mt::client::MapTileClient<FlightInfo, Coordinate2D, FlightMapper, FlightTile, double>> servers;
     for (const auto &loc : hpx::find_all_localities()) {

--- a/src/map-tile/test/runtime_tests.cpp
+++ b/src/map-tile/test/runtime_tests.cpp
@@ -22,7 +22,6 @@
 #include <iostream>
 #include <mutex>
 
-
 int main(int argc, char *argv[]) {
     return Catch::Session().run(argc, argv);
 }
@@ -115,15 +114,19 @@ struct FlightTile {
     void receive(const mt::ctx::ReduceContext<FlightInfo, mt::coordinates::Coordinate2D> &ctx, const mt::coordinates::Coordinate2D &key,
                  const FlightInfo &value) {
         // Just increment a simple counter
+        spdlog::info("Receiving");
         const std::lock_guard<std::mutex> lock(_m);
         _flight_matrix.coeffRef(key.get_dim0(), key.get_dim1()) += 1;
+        spdlog::info("Receive done");
     }
 
     void compute(const mt::ctx::ReduceContext<FlightInfo, mt::coordinates::Coordinate2D> &ctx) {
+        spdlog::info("Doing the compute");
         _local_total = _flight_matrix.sum();
     }
 
     double reduce(const mt::ctx::ReduceContext<FlightInfo, mt::coordinates::Coordinate2D> &ctx) {
+        spdlog::info("Doing the reduce");
         return _local_total;
     }
 

--- a/src/map-tile/test/runtime_tests.cpp
+++ b/src/map-tile/test/runtime_tests.cpp
@@ -6,7 +6,7 @@
 #define CATCH_CONFIG_RUNNER
 
 #include <hpx/config.hpp>
-#include <hpx/hpx_init.hpp>
+#include <hpx/hpx_main.hpp>
 #include <absl/strings/str_split.h>
 #include <boost/bimap.hpp>
 #include "catch2/catch.hpp"
@@ -23,14 +23,12 @@
 #include <mutex>
 
 
-int main(int argc, char* argv[]) {
-    hpx::init(argc, argv);
+int main(int argc, char *argv[]) {
+    return Catch::Session().run(argc, argv);
 }
 
-int hpx_main(int argc, char* argv[]) {
-    const auto res = Catch::Session().run(argc, argv);
-    return hpx::finalize(res);
-}
+// Some atomics
+std::atomic_int flights(0);
 
 typedef boost::bimap<std::string, std::size_t> flight_bimap;
 typedef flight_bimap::value_type position;


### PR DESCRIPTION
Refactor emit handling to buffer values before sending in chunks.

Added an `EMIT_SIZE` cmake variable which controls how big to make the buffer before flushing it (defaults to 4k).

Dramatically improves performance and the refactor helps with code clarity as well.

Also closes #9 