### PR TITLE
Improve Parquet write performance

### DIFF
--- a/src/components/src/WeekSplitter.cpp
+++ b/src/components/src/WeekSplitter.cpp
@@ -4,7 +4,7 @@
 #include "components/WeekSplitter.hpp"
 
 #include "spdlog/spdlog.h"
-#include <hpx/parallel/execution.hpp>
+#include <hpx/execution.hpp>
 #include <hpx/parallel/algorithms/transform_reduce.hpp>
 #include <utility>
 


### PR DESCRIPTION
Update parquet writing performance.

The ParquetWriter class now writes 10k rows per group and with Snappy compression.

For the centrality application, we now write as many files as possible using HPX's parallel `for_each`.

closes #7 