### PR TITLE
Refactor Tiling inserts to improve performance.

### DIFF
--- a/src/centrality/SafegraphCBGTiler.hpp
+++ b/src/centrality/SafegraphCBGTiler.hpp
@@ -12,6 +12,7 @@
 #include <components/CBGShapefileWrapper.hpp>
 #include <map-tile/ctx/Context.hpp>
 #include <shared/data.hpp>
+#include <mutex>
 
 class SafegraphCBGTiler {
 
@@ -28,6 +29,7 @@ public:
     reduce(const mt::ctx::ReduceContext<v2, mt::coordinates::Coordinate3D> &ctx) const;
 
 private:
+    void populate_graph(const mt::ctx::ReduceContext<v2, mt::coordinates::Coordinate3D> &ctx);
     void write_parquet(const mt::ctx::ReduceContext<v2, mt::coordinates::Coordinate3D> &ctx) const;
 
     std::unique_ptr<components::detail::CBGOffsetCalculator> _oc;
@@ -36,6 +38,8 @@ private:
     std::unique_ptr<components::TemporalGraphs> _graphs;
     components::TileConfiguration _tc;
     date::sys_days _start_date;
+    std::vector<std::vector<v2>> _staging;
+    std::mutex _m;
 };
 
 

--- a/src/epi-rank/SafegraphCountyTiler.hpp
+++ b/src/epi-rank/SafegraphCountyTiler.hpp
@@ -24,13 +24,16 @@ public:
     void compute(const mt::ctx::ReduceContext<county_visit, mt::coordinates::Coordinate3D> &ctx);
 
 private:
+    void populate_graph(const mt::ctx::ReduceContext<county_visit, mt::coordinates::Coordinate3D> &ctx);
     void write_eigenvalues(std::size_t offset, const blaze::DynamicVector<complex<double>, blaze::columnVector> &values) const;
     std::unique_ptr<components::detail::CountyOffsetCalculator> _oc;
     std::unique_ptr<components::CountyShapefileWrapper> _c_wrapper;
     components::TileConfiguration _tc;
     date::sys_days _start_date;
-    std::unique_ptr<BlazeMatricies> matricies;
+    std::unique_ptr<BlazeMatricies> _matricies;
     std::string _output_path;
+    std::vector<std::vector<county_visit>> _staging;
+    std::mutex _m;
 };
 
 

--- a/src/io/src/parquet.cpp
+++ b/src/io/src/parquet.cpp
@@ -37,7 +37,8 @@ namespace io {
     arrow::Status Parquet::write(const arrow::Table &table, bool append) const {
         parquet::WriterProperties::Builder builder;
         // Enable Snappy compression, to make things smaller
-        builder.compression(_compressor);
+        // Disabling until #33 is resolved.
+//        builder.compression(_compressor);
         const auto writer_props = builder.build();
 
         shared_ptr<arrow::io::FileOutputStream> outfile;


### PR DESCRIPTION
A VTune analysis showed that we were spending a ton of time inserting values into the tile matrices. This meant the mappers were blocked waiting for the operations to finish.

Added an intermediate step in which we insert everything into an internal vector set and then, before performing the computation step, we insert everything into the matrix at once.

Still not very efficient, but at least we're not blocking the few mappers as much.