### PR TITLE
Update Github Actions to latest versions of tasks.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,24 +20,24 @@ jobs:
         with:
           submodules: true
 
-      - uses: lukka/get-cmake@v3.17.1
+      - uses: lukka/get-cmake@latest
         name: Install cmake
 
       - name: Set vcpkg's response file path used as part of cache's key.
-        uses: lukka/set-shell-env@master
+        uses: lukka/set-shell-env@latest
         with:
           VCPKGRESPONSEFILE: ${{ github.workspace }}/cmake/vcpkg_${{ matrix.triplet }}.txt
 
       - name: (macOS) Install dependencies
         if: runner.os == 'macOS'
         run: |
-          brew install hwloc bison flex gdal pkg-config
+          brew install hwloc bison flex gdal pkg-config ccache
 
       - name: (Linux) Install dependencies
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install libxml2-dev libnuma-dev gcc-9 g++-9 libhwloc-dev
+          sudo apt-get install libxml2-dev libnuma-dev gcc-9 g++-9 libhwloc-dev ccache
 
       - name: Install Python dependencies
         run: |
@@ -50,7 +50,7 @@ jobs:
           CMAKE_EXTRA_ARGS: '-DCMAKE_C_COMPILER=/usr/bin/gcc-9 -DCMAKE_CXX_COMPILER=/usr/bin/g++-9'
 
       - name: Restore artifacts, or run vcpkg, build and cache artifacts
-        uses: lukka/run-vcpkg@v3
+        uses: lukka/run-vcpkg@latest
         id: runvcpkg
         with:
           vcpkgArguments: '@${{ env.VCPKGRESPONSEFILE }}'
@@ -59,7 +59,7 @@ jobs:
           appendedCacheKey: ${{ hashFiles( env.VCPKGRESPONSEFILE ) }}
 
       - name: Run CMake with Ninja
-        uses: lukka/run-cmake@v2
+        uses: lukka/run-cmake@latest
         id: runcmake
         with:
           cmakeListsOrSettingsJson: "CMakeListsTxtAdvanced"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -20,6 +20,22 @@ jobs:
         with:
           submodules: true
 
+      - name: Prepare ccache timestamp
+        id: ccache_cache_timestamp
+        shell: cmake -P {0}
+        run: |
+          string(TIMESTAMP current_date "%Y-%m-%d-%H;%M;%S" UTC)
+          message("::set-output name=timestamp::${current_date}")
+
+      - name: Cache ccache builds
+        uses: action/cache@v2
+        with:
+          path: |
+            .ccache
+          key: ${{ runner.os }}-ccache-${{ steps.ccache_cache_timestamp.outputs.timestamp }}
+          restore-keys: |
+            ${{ runner.os }}-ccache-
+
       - uses: lukka/get-cmake@latest
         name: Install cmake
 
@@ -50,7 +66,7 @@ jobs:
           CMAKE_EXTRA_ARGS: '-DCMAKE_C_COMPILER=/usr/bin/gcc-9 -DCMAKE_CXX_COMPILER=/usr/bin/g++-9'
 
       - name: Restore artifacts, or run vcpkg, build and cache artifacts
-        uses: lukka/run-vcpkg@latest
+        uses: lukka/run-vcpkg@v6.1
         id: runvcpkg
         with:
           vcpkgArguments: '@${{ env.VCPKGRESPONSEFILE }}'
@@ -65,7 +81,7 @@ jobs:
           cmakeListsOrSettingsJson: "CMakeListsTxtAdvanced"
           useVcpkgToolchainFile: true
           buildDirectory: '${{ github.workspace }}/build/'
-          cmakeAppendedArgs: '-GNinja -DCI=ON ${{ env.CMAKE_EXTRA_ARGS }}'
+          cmakeAppendedArgs: '-GNinja -DCI=ON -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache ${{ env.CMAKE_EXTRA_ARGS }}'
 
       - name: Unit Tests
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
           appendedCacheKey: ${{ hashFiles( env.VCPKGRESPONSEFILE ) }}
 
       - name: Run CMake with Ninja
-        uses: lukka/run-cmake@latest
+        uses: lukka/run-cmake@v3.3
         id: runcmake
         with:
           cmakeListsOrSettingsJson: "CMakeListsTxtAdvanced"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,6 @@ jobs:
       - name: (Linux) Install dependencies
         if: runner.os == 'Linux'
         run: |
-          sudo add-apt-repository ppa:ubuntugis/ppa
           sudo apt-get update
           sudo apt-get install libxml2-dev libnuma-dev gcc-9 g++-9 libhwloc-dev ccache libgdal-dev
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,8 +52,9 @@ jobs:
       - name: (Linux) Install dependencies
         if: runner.os == 'Linux'
         run: |
+          sudo add-apt-repository ppa:ubuntugis/ppa
           sudo apt-get update
-          sudo apt-get install libxml2-dev libnuma-dev gcc-9 g++-9 libhwloc-dev ccache
+          sudo apt-get install libxml2-dev libnuma-dev gcc-9 g++-9 libhwloc-dev ccache libgdal-dev
 
       - name: Install Python dependencies
         run: |
@@ -81,7 +82,7 @@ jobs:
           cmakeListsOrSettingsJson: "CMakeListsTxtAdvanced"
           useVcpkgToolchainFile: true
           buildDirectory: '${{ github.workspace }}/build/'
-          cmakeAppendedArgs: '-GNinja -DCI=ON -D CMAKE_C_COMPILER_LAUNCHER=ccache -D CMAKE_CXX_COMPILER_LAUNCHER=ccache ${{ env.CMAKE_EXTRA_ARGS }}'
+          cmakeAppendedArgs: '-GNinja -DCI=ON -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache ${{ env.CMAKE_EXTRA_ARGS }}'
 
       - name: Unit Tests
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,7 +28,7 @@ jobs:
           message("::set-output name=timestamp::${current_date}")
 
       - name: Cache ccache builds
-        uses: action/cache@v2
+        uses: actions/cache@v2
         with:
           path: |
             .ccache
@@ -60,13 +60,13 @@ jobs:
           pip3 install pandas
 
       - name: (Linux) Set GCC9 as default compiler
-        uses: lukka/set-shell-env@master
+        uses: lukka/set-shell-env@v1
         if: runner.os == 'Linux'
         with:
           CMAKE_EXTRA_ARGS: '-DCMAKE_C_COMPILER=/usr/bin/gcc-9 -DCMAKE_CXX_COMPILER=/usr/bin/g++-9'
 
       - name: Restore artifacts, or run vcpkg, build and cache artifacts
-        uses: lukka/run-vcpkg@v6.1
+        uses: lukka/run-vcpkg@v6
         id: runvcpkg
         with:
           vcpkgArguments: '@${{ env.VCPKGRESPONSEFILE }}'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,7 +40,7 @@ jobs:
         name: Install cmake
 
       - name: Set vcpkg's response file path used as part of cache's key.
-        uses: lukka/set-shell-env@latest
+        uses: lukka/set-shell-env@v1
         with:
           VCPKGRESPONSEFILE: ${{ github.workspace }}/cmake/vcpkg_${{ matrix.triplet }}.txt
 


### PR DESCRIPTION
This should address an issue with unsecure additions to PATH, which was causing the builds to fail.

Also add ccache support, which should make our builds a lot faster.